### PR TITLE
19.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@wasm-fmt/clang-format",
     "author": "magic-akari <akari.ccino@gamil.com>",
-    "version": "18.1.8",
+    "version": "19.1.0",
     "description": "A wasm based clang-format",
     "main": "clang-format.js",
     "types": "clang-format.d.ts",


### PR DESCRIPTION
- Upgrade clang-format to 19.1.0
- Directly compile ClangFormat.cpp from the original LLVM repository as a cli build target
- Closes: #26 
- Closes: #27 