### PR TITLE
Update LLVM version to 20.1.7

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,11 +20,11 @@ if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE "MinSizeRel")
 endif()
 
-set(LLVM_VERSION "20.1.6")
+set(LLVM_VERSION "20.1.7")
 
 FetchContent_Declare(llvm_project
     URL "https://github.com/llvm/llvm-project/releases/download/llvmorg-${LLVM_VERSION}/llvm-project-${LLVM_VERSION}.src.tar.xz"
-    URL_HASH SHA256=5c70549d524284c184fe9fbff862c3d2d7a61b787570611b5a30e5cc345f145e
+    URL_HASH SHA256=cd8fd55d97ad3e360b1d5aaf98388d1f70dfffb7df36beee478be3b839ff9008
     TLS_VERIFY TRUE
     DOWNLOAD_EXTRACT_TIMESTAMP TRUE
 )


### PR DESCRIPTION
Automatic LLVM version update

- Updated from 20.1.6 to 20.1.7
- Automatically updated SHA256 checksum

Generated by automated workflow.