### PR TITLE
Update LLVM version to 21.1.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,11 +20,11 @@ if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE "MinSizeRel")
 endif()
 
-set(LLVM_VERSION "21.1.0")
+set(LLVM_VERSION "21.1.1")
 
 FetchContent_Declare(llvm_project
     URL "https://github.com/llvm/llvm-project/releases/download/llvmorg-${LLVM_VERSION}/llvm-project-${LLVM_VERSION}.src.tar.xz"
-    URL_HASH SHA256=1672e3efb4c2affd62dbbe12ea898b28a451416c7d95c1bd0190c26cbe878825
+    URL_HASH SHA256=8863980e14484a72a9b7d2c80500e1749054d74f08f8c5102fd540a3c5ac9f8a
     TLS_VERIFY TRUE
     DOWNLOAD_EXTRACT_TIMESTAMP TRUE
 )


### PR DESCRIPTION
Automatic LLVM version update

- Updated from 21.1.0 to 21.1.1
- Automatically updated SHA256 checksum

Generated by automated workflow.