### PR TITLE
Update LLVM version to 22.1.8

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,11 +36,11 @@ if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE "MinSizeRel")
 endif()
 
-set(LLVM_VERSION "22.1.7")
+set(LLVM_VERSION "22.1.8")
 
 FetchContent_Declare(llvm_project
     URL "https://github.com/llvm/llvm-project/releases/download/llvmorg-${LLVM_VERSION}/llvm-project-${LLVM_VERSION}.src.tar.xz"
-    URL_HASH SHA256=5cc4a3f12bba50b6bdfb4b61bdc852117a0ff2517807c3902fc13267fb93562e
+    URL_HASH SHA256=922f1817a0df7b1489272d18134ee0087a8b068828f87ac63b9861b1a9965888
     TLS_VERIFY TRUE
     DOWNLOAD_EXTRACT_TIMESTAMP TRUE
 )


### PR DESCRIPTION
Automatic LLVM version update

- Updated from 22.1.7 to 22.1.8
- Automatically updated SHA256 checksum

Generated by automated workflow.